### PR TITLE
Small qalculate tweaks/fixes

### DIFF
--- a/qalculate/src/extension.cpp
+++ b/qalculate/src/extension.cpp
@@ -138,11 +138,13 @@ void Qalculate::Extension::handleQuery(Core::Query * query) const {
         result = QString::fromStdString(mathStructure.print(d->po));
         auto item = make_shared<StandardItem>(Plugin::id());
         item->setIconPath(d->iconPath);
-        item->setText(result);
-        if ( mathStructure.isApproximate() )
+        if ( mathStructure.isApproximate() ) {
             item->setSubtext(QString("Approximate result of '%1'").arg(cmd));
-        else
+            result.prepend("≈");
+        } else {
             item->setSubtext(QString("Result of '%1'").arg(cmd));
+        }
+        item->setText(result);
         item->setCompletion(QString("=%1").arg(result));
         item->addAction(make_shared<ClipAction>("Copy result to clipboard", result));
         item->addAction(make_shared<ClipAction>("Copy equation to clipboard", QString("%1 = %2").arg(cmd, item->text())));

--- a/qalculate/src/extension.cpp
+++ b/qalculate/src/extension.cpp
@@ -123,9 +123,11 @@ void Qalculate::Extension::handleQuery(Core::Query * query) const {
 
     QString result, error, cmd = query->string().trimmed();
     MathStructure mathStructure;
+
     try {
         string expr = d->calculator->unlocalizeExpression(query->string().toStdString(), d->eo.parse_options);
         mathStructure = d->calculator->calculate(expr, d->eo);
+        mathStructure.setPrecision(d->calculator->getPrecision());
         while (d->calculator->message()) {
             error.append(d->calculator->message()->c_message());
             d->calculator->nextMessage();


### PR DESCRIPTION
Setting the precision in the calculator instance doesn't seem to work so we have to set it in the mathstructure too.
The other thing is the approximation symbol in front of an approximate result (mimics behaviour of many scientific calculators and makes it more obvious that you are dealing with approximations. this is especially useful if the precision is set to a pretty low number).