### PR TITLE
Find and use python libraries and headers

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,6 +5,8 @@ PROJECT(python)
 FILE(GLOB_RECURSE SRC src/* metadata.json)
 
 find_package(Qt5 5.5.0 REQUIRED COMPONENTS Widgets)
+find_package(PythonLibs)
+include_directories(${PYTHON_INCLUDE_DIRS})
 add_subdirectory(pybind11)
 
 add_library(${PROJECT_NAME} SHARED ${SRC} ${PROJECT_NAME}.qrc)
@@ -14,6 +16,7 @@ target_include_directories(${PROJECT_NAME} PRIVATE src/)
 target_link_libraries(${PROJECT_NAME}
     PUBLIC
         ${Qt5Widgets_LIBRARIES}
+        ${PYTHON_LIBRARIES}
     PRIVATE
         pybind11::embed
         albertcore


### PR DESCRIPTION
When building with -Wl,--no-undefined, the python plugin needs to be linked to a python library.

On my systems, Python.h couldn't be found without specifying an include directory containing python headers (e.g. /usr/include/python3.5m).

Here are two successful builds that failed to find Python.h without this change:
* [i586](http://pkgsubmit.mageia.org/uploads/done/cauldron/core/release/20180614061525.buchan.duvel.39190/albert-0.14.21-1.mga7/build.0.20180614061704.log)
* [x86_64](http://pkgsubmit.mageia.org/uploads/done/cauldron/core/release/20180614061525.buchan.duvel.39190/albert-0.14.21-1.mga7/build.0.20180614061706.log)

[Here](http://pkgsubmit.mageia.org/uploads/failure/cauldron/core/release/20180614051641.buchan.duvel.1512/log/albert-0.14.21-1.mga7/build.0.20180614051801.log) is a previous attempt which had hard-coded the python include directory for the python version on my machine (running a stable release).