### PR TITLE
Change MATE logout command to `mate-session-save --logout-dialog`

### DIFF
--- a/system/src/extension.cpp
+++ b/system/src/extension.cpp
@@ -111,7 +111,7 @@ QString defaultCommand(SupportedCommands command){
         else if (de == "MATE")
             switch (command) {
             case LOCK:      return "mate-screensaver-command --lock";
-            case LOGOUT:    return "mate-session-save --logout";
+            case LOGOUT:    return "mate-session-save --logout-dialog";
             case SUSPEND:   return "sh -c \"mate-screensaver-command --lock && systemctl suspend -i\"";
             case HIBERNATE: return "sh -c \"mate-screensaver-command --lock && systemctl hibernate -i\"";
             case REBOOT:    return "mate-session-save --shutdown-dialog";


### PR DESCRIPTION
Change MATE logout command from `mate-session-save --logout` to `mate-session-save --logout-dialog` so that it brings up a log out dialog instead of just immediately logging out. The current behavior surprised me after having used the Shut Down option many times!