### PR TITLE
[Applications] Add option to use the non-localized 'name' for lookup

### DIFF
--- a/applications/src/configwidget.ui
+++ b/applications/src/configwidget.ui
@@ -58,6 +58,13 @@
           <string>Additionally use generic name for lookup</string>
          </property>
         </widget>
+      </item>
+      <item>
+        <widget class="QCheckBox" name="checkBox_useNonLocalizedName">
+         <property name="text">
+          <string>Additionally use non-localized name for lookup</string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QCheckBox" name="checkBox_fuzzy">


### PR DESCRIPTION
I have the behavior of using the english/international name for some apps, e.g. _settings_ for the _chrome-control-center_, which is called _Einstellungen_ in German (my system locale).

Some desktop files offer a field `GenericName`, others a field `Name` without a locale (indicated by brackets, e.g. `Name[de]`) for this _international_ name.

This pull requests adds a checkbox and the code to use this field for indexing where possible.

IMHO this is a useful feature since it doesn't clutter the search and is completely optional/can be switched off


This is also a reaction to my [initial issue here](https://github.com/albertlauncher/albert/issues/689)