### PR TITLE
[ssh] Allow hyphens to be part of hostnames

### DIFF
--- a/ssh/src/extension.cpp
+++ b/ssh/src/extension.cpp
@@ -122,7 +122,7 @@ void Ssh::Extension::handleQuery(Query * query) const {
     else
     {
         // Check sanity of input
-        QRegularExpression re(R"raw(^(?:(\w+)@)?\[?((?:\w[\w:]*|[\w\.]*))\]?(?::(\d+))?$)raw");
+        QRegularExpression re(R"raw(^(?:(\w+)@)?\[?((?:\w[\w:-]*|[\w\.-]*))\]?(?::(\d+))?$)raw");
         QRegularExpressionMatch match = re.match(trimmed);
 
         if (match.hasMatch())


### PR DESCRIPTION
Hello,
As explained in issue https://github.com/albertlauncher/albert/issues/824, word regexp `\w` does not include hyphens. Here is a proposal to fix the issue and getting the ability to use Albert SSH plugin with hosts including hyphens in their names.