### PR TITLE
[fix]gnome-screensaver-command -l is no more in gnome3.8

### DIFF
--- a/system/src/extension.cpp
+++ b/system/src/extension.cpp
@@ -80,7 +80,7 @@ QString defaultCommand(SupportedCommands command){
 
         if (de == "Unity" || de == "Pantheon" || de == "GNOME")
             switch (command) {
-            case LOCK:      return "gnome-screensaver-command --lock";
+            case LOCK:      return "dbus-send --type=method_call --dest=org.gnome.ScreenSaver /org/gnome/ScreenSaver org.gnome.ScreenSaver.Lock";
             case LOGOUT:    return "gnome-session-quit --logout";
             case SUSPEND:   break ;
             case HIBERNATE: break ;


### PR DESCRIPTION
refreence https://choffee.co.uk/thoughtsplurge/posts/2013/07/11/lock_gnome_screensaver/