### PR TITLE
[Chrome bookmarks] Adding Brave support

### DIFF
--- a/chromebookmarks/src/extension.cpp
+++ b/chromebookmarks/src/extension.cpp
@@ -38,7 +38,8 @@ const char* EXT_ID = "org.albert.extension.chromebookmarks";
 const char* CFG_PATH  = "bookmarkfile";
 const char* CFG_FUZZY = "fuzzy";
 const bool  DEF_FUZZY = false;
-const char *potentialExecutableNames[] = {"chromium",
+const char *potentialExecutableNames[] = {"brave",
+                                          "chromium",
                                           "chromium-browser",
                                           "chrome",
                                           "chrome-browser",
@@ -46,7 +47,8 @@ const char *potentialExecutableNames[] = {"chromium",
                                           "google-chrome-beta",
                                           "google-chrome-stable",
                                           "google-chrome-unstable"};
-const char *potentialConfigLocations[] = {"chromium",
+const char *potentialConfigLocations[] = { "BraveSoftware/Brave-Browser"
+                                          "chromium",
                                           "google-chrome"};
 
 /** ***************************************************************************/


### PR DESCRIPTION
Chrome bookmarks
Adding the executable name and the .config path to the list of Chrome/ium execs/paths. 
This is enough to enable support for the Brave navigator (with the path change in the extension settings)