### PR TITLE
Respect the Include keyword (closes albertlauncher/albert#840)

### DIFF
--- a/ssh/metadata.json
+++ b/ssh/metadata.json
@@ -1,7 +1,7 @@
 {
     "id" :              "org.albert.extension.ssh",
     "name" :            "Secure Shell",
-    "version" :         "1.1",
+    "version" :         "1.2",
     "platform" :        "All",
     "group" :           "Extensions",
     "author" :          "Manuel Schneider",


### PR DESCRIPTION
Adds 2 TODOs:
* Place tilde expansion somewhere reuseable/else
* Make this pseudo-tilde expansion a proper one