### PR TITLE
fix(websearch): searchterm avoid extra space

### DIFF
--- a/websearch/src/extension.cpp
+++ b/websearch/src/extension.cpp
@@ -43,7 +43,7 @@ vector<Websearch::SearchEngine> defaultSearchEngines = {
 
 shared_ptr<Core::Item> buildWebsearchItem(const Websearch::SearchEngine &se, const QString &searchterm) {
 
-    QString urlString = QString(se.url).replace("%s", QUrl::toPercentEncoding(searchterm));
+    QString urlString = QString(se.url).replace("%s", QUrl::toPercentEncoding(searchterm.trimmed()));
     QUrl url = QUrl(urlString);
     QString desc = QString("Start %1 search in your browser").arg(se.name);
 


### PR DESCRIPTION
fix(websearch): searchterm should be trimmed to avoid extra space before the actual term words

the builtin Search engine does not have this problem.

when you add custom engine, the problem comes.

for example add an engine named "foo",  the trigger is `foo` , and the url is:  `https://example.com/q=%s`

when you just type like the builtin Google, let's say we typed  `gg hello`, the correct URL generated:

it is `https://www.google.com/search?q=hello`

but for the custom engine, we typed  `foo hello`, the result is:    `https://example.com/q= hello`

be aware that the `space` before `hello`

and if you need to avoid the problem, you need to type `foohello`.  

this is not as the same rule as the builtin ones (like Google)

maybe there's better solution ? 

why only the builtin engine does not have the problem?
