### PR TITLE
[Python] Fix logic error when unloading.

### DIFF
--- a/python/src/pythonmodulev1.cpp
+++ b/python/src/pythonmodulev1.cpp
@@ -330,7 +330,7 @@ void Python::PythonModuleV1::load(){
 /** ***************************************************************************/
 void Python::PythonModuleV1::unload(){
 
-    if (!(d->state == State::Unloaded || d->state == State::Unloaded))
+    if (d->state == State::Unloaded)
         return;
 
     if (d->state == State::Loaded) {


### PR DESCRIPTION
While unloading module, we should check state is unloaded.



Signed-off-by: corvofeng <corvofeng@gmail.com>