### PR TITLE
Add albert-python-api module definition

### DIFF
--- a/applications/src/extension.cpp
+++ b/applications/src/extension.cpp
@@ -408,7 +408,7 @@ vector<shared_ptr<StandardIndexItem>> Applications::Private::indexApplications()
             subtext = commandLine;
 
         // Set index strings
-        vector<IndexableItem::IndexString> indexStrings;
+        vector<IndexItem::IndexString> indexStrings;
         indexStrings.emplace_back(name, UINT_MAX);
 
         QStringList excludes = {
@@ -582,10 +582,10 @@ QWidget *Applications::Extension::widget(QWidget *parent) {
 /** ***************************************************************************/
 void Applications::Extension::handleQuery(Core::Query * query) const {
 
-    const vector<shared_ptr<Core::IndexableItem>> &indexables = d->offlineIndex.search(query->string());
+    const vector<shared_ptr<Core::IndexItem>> &indexables = d->offlineIndex.search(query->string());
 
     vector<pair<shared_ptr<Core::Item>,uint>> results;
-    for (const shared_ptr<Core::IndexableItem> &item : indexables)
+    for (const shared_ptr<Core::IndexItem> &item : indexables)
         results.emplace_back(static_pointer_cast<Core::StandardIndexItem>(item), 1);
 
     query->addMatches(make_move_iterator(results.begin()),

--- a/chromium/src/extension.cpp
+++ b/chromium/src/extension.cpp
@@ -258,10 +258,10 @@ void Chromium::Extension::setFuzzy(bool b) {
 /** ***************************************************************************/
 void Chromium::Extension::handleQuery(Core::Query * query) const {
 
-    const vector<shared_ptr<Core::IndexableItem>> &indexables = d->offlineIndex.search(query->string());
+    const vector<shared_ptr<Core::IndexItem>> &indexables = d->offlineIndex.search(query->string());
 
     vector<pair<shared_ptr<Core::Item>,uint>> results;
-    for (const shared_ptr<Core::IndexableItem> &item : indexables)
+    for (const shared_ptr<Core::IndexItem> &item : indexables)
         results.emplace_back(std::static_pointer_cast<Core::StandardIndexItem>(item), 0);
 
     query->addMatches(std::make_move_iterator(results.begin()),

--- a/files/src/extension.cpp
+++ b/files/src/extension.cpp
@@ -387,11 +387,11 @@ void Files::Extension::handleQuery(Core::Query * query) const {
         }
 
         // Search for matches
-        const vector<shared_ptr<IndexableItem>> &indexables = d->offlineIndex.search(query->string());
+        const vector<shared_ptr<IndexItem>> &indexables = d->offlineIndex.search(query->string());
 
         // Add results to query
         vector<pair<shared_ptr<Core::Item>,uint>> results;
-        for (const shared_ptr<Core::IndexableItem> &item : indexables)
+        for (const shared_ptr<Core::IndexItem> &item : indexables)
             // TODO `Search` has to determine the relevance. Set to 0 for now
             results.emplace_back(static_pointer_cast<File>(item), 0);
 

--- a/files/src/file.cpp
+++ b/files/src/file.cpp
@@ -116,8 +116,8 @@ std::vector<std::shared_ptr<Action> > Files::File::buildFileActions(const QStrin
 }
 
 /** ***************************************************************************/
-vector<IndexableItem::IndexString> Files::File::indexStrings() const {
-    vector<IndexableItem::IndexString> res;
+vector<IndexItem::IndexString> Files::File::indexStrings() const {
+    vector<IndexItem::IndexString> res;
     res.emplace_back(name(), UINT_MAX);
     // TODO ADD PATH
     return res;

--- a/files/src/file.h
+++ b/files/src/file.h
@@ -5,11 +5,11 @@
 #include <QMimeType>
 #include <map>
 #include <vector>
-#include "albert/indexable.h"
+#include "albert/indexitem.h"
 
 namespace Files {
 
-class File : public Core::IndexableItem
+class File : public Core::IndexItem
 {
 public:
 
@@ -18,7 +18,7 @@ public:
     QString subtext() const override;
     QString completion() const override;
     QString iconPath() const override;
-    std::vector<Core::IndexableItem::IndexString> indexStrings() const override;
+    std::vector<Core::IndexItem::IndexString> indexStrings() const override;
     std::vector<std::shared_ptr<Core::Action>> actions() override;
 
     static std::vector<std::shared_ptr<Core::Action>> buildFileActions(const QString &filePath);

--- a/firefoxbookmarks/src/extension.cpp
+++ b/firefoxbookmarks/src/extension.cpp
@@ -417,10 +417,10 @@ QWidget *FirefoxBookmarks::Extension::widget(QWidget *parent) {
 /** ***************************************************************************/
 void FirefoxBookmarks::Extension::handleQuery(Core::Query *query) const {
 
-    const vector<shared_ptr<Core::IndexableItem>> &indexables = d->offlineIndex.search(query->string());
+    const vector<shared_ptr<Core::IndexItem>> &indexables = d->offlineIndex.search(query->string());
 
     vector<pair<shared_ptr<Core::Item>,uint>> results;
-    for (const shared_ptr<Core::IndexableItem> &item : indexables)
+    for (const shared_ptr<Core::IndexItem> &item : indexables)
         results.emplace_back(static_pointer_cast<Core::StandardIndexItem>(item), 0);
 
     query->addMatches(make_move_iterator(results.begin()),

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,1 +1,3 @@
 __pycache__
+albert_python_api.egg-info
+dist

--- a/python/albert/__init__.py
+++ b/python/albert/__init__.py
@@ -1,0 +1,1 @@
+raise ImportError("albert module is only available from the plugin environment")

--- a/python/albert/__init__.pyi
+++ b/python/albert/__init__.pyi
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""
+Albert Python module interface specification v0.4
+
+To work as an albert extension Python modules have to have a particular
+interface described below. The Python extension also defines an embedded module
+albert which allows the Python modules to interact with the core. The interface
+specification and the built-in albert module are versioned together and form the
+versioned Python interface. The Python interface is not final. They are
+prototypes and intended to be improved on user feedback.
+
+This file is a .pyi declaration of the interface, suitable for use with mypy
+type checkers, as well as Python language servers which provide completion. It
+contains inline documentation copied from the README [1].
+
+[1]: https://github.com/albertlauncher/plugins/tree/master/python
+
+The following portion of the docstring describes the variables and functions
+which each Python extension module must implement. The remainder of this file's
+contents are the declarations of the albert module itself.
+
+Variables:
+
+__doc__       Optional [string]. The docstring of the module is used as
+              description of the extension. This string will be displayed to the
+              user.
+__title__     MANDATORY [string]. This variable should hold the pretty name of
+              the extension. This string will be displayed to the user.
+__version__   MANDATORY [string]. The versioning scheme should be
+              [iid_major].[iid_minor].[verion]. The interface id (iid_*) should
+              match the pyton interface version. version is the extensions
+              version.
+              Note that within each iid_maj the API is backwards compatible, but
+              as long as albert is in alpha stage iid_major will be 0 and API
+              may brake any time.
+__triggers__  Optional [string, list of strings]. If this extension should be
+              run exclusively, this variable has to hold the trigger that causes
+              the extension to be executed.
+__authors__   Optional [string, list of strings]. This variable should hold the
+              name of the author of the extension.
+__exec_deps__ Optional [string, list of strings]. This string should contain any
+              dependencies the extension needs to be used. The name of the
+              dependency has to match the name of the executable in $PATH.
+__py_deps__   Optional [string, list of strings]. This string should contain any
+              dependencies the extension needs to be used. The name of the
+              dependency has to match the name of the package in the PyPI.
+
+Functions:
+
+handleQuery(Query) MANDATORY. This is the crucial part of a Python module. When
+                   the user types a query, this function is called with a query
+                   object representing the current query execution. This
+                   function should return a list of Item objects.  See the Item
+                   class section below.
+initialize()       Optional. This function is called when the extension is
+                   loaded. Although you could technically run your
+                   initialization code in global scope, it is recommended to
+                   initialize your extension in this function. If your extension
+                   fails to initialize you can raise exceptions here, which are
+                   displayed to the user.
+finalize()         Optional. This function is called when the extension is
+                   unloaded.
+"""
+from enum import Enum
+from typing import Any
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Union
+
+
+def debug(arg: Any) -> None:
+    """
+    Log a message to stdout. Note that debug is effectively a NOP in release
+    builds. Puts the passed object into str() for convenience. The messages are
+    logged using the QLoggingCategory of the python extension and therefore are
+    subject to filter rules.
+    """
+
+
+def info(arg: Any) -> None:
+    """
+    Log a message to stdout at the "info" log level. Puts the passed object into
+    str() for convenience. The messages are logged using the QLoggingCategory of
+    the python extension and therefore are subject to filter rules.
+    """
+
+
+def warning(arg: Any) -> None:
+    """
+    Log a message to stdout at the "info" log level. Puts the passed object into
+    str() for convenience. The messages are logged using the QLoggingCategory of
+    the python extension and therefore are subject to filter rules.
+    """
+
+
+def critical(arg: Any) -> None:
+    """
+    Log a message to stdout at the "info" log level. Puts the passed object into
+    str() for convenience. The messages are logged using the QLoggingCategory of
+    the python extension and therefore are subject to filter rules.
+    """
+
+
+def iconLookup(iconName: Union[str, List[str]]) -> Union[str, List[str]]:
+    """
+    Perform xdg icon lookup and return a path. Empty if nothing found.
+    This function has two forms. Called with a single string argument, it
+    returns a single (possibly empty) string. Called with a list of string
+    arguments, it returns a list of (possibly empty) string results.
+    """
+
+
+def cacheLocation() -> str:
+    """
+    Returns the writable cache location of the app. (E.g. $HOME/.cache/albert/
+    on Linux)
+    """
+
+
+def configLocation() -> str:
+    """
+    Returns the writable config location of the app. (E.g. $HOME/.cache/albert/
+    on Linux)
+    """
+
+
+def dataLocation() -> str:
+    """
+    Returns the writable data location of the app. (E.g. $HOME/.cache/albert/
+    on Linux)
+    """
+
+
+class Query(object):
+
+    """
+    The query class represents a query execution. It holds the necessary
+    information to handle a Query. It is passed to the handleQuery function.
+    """
+
+    string: str
+    """
+    This is the actual query string without the trigger. If the query is not
+    triggered this string equals rawstring.
+    """
+
+    rawString: str
+    """
+    This is the full query string including the trigger. If the query is not
+    triggered this string equals string.
+    """
+
+    trigger: str
+    """
+    This is the trigger that has been used to start this extension.
+    """
+
+    isTriggered: bool
+    """
+    Indicates that this query has been triggered.
+    """
+
+    isValid: bool
+    """
+    This flag indicates if the query is valid. A query is valid untill the query
+    manager cancels it. You should regularly check this flag and abort the query
+    handling if the flag is False to release threads in the threadpool for the
+    next query.
+    """
+
+    def disableSort(self) -> bool:
+        """
+        Indicates that this query has been triggered.
+        """
+
+
+class ItemBase(object):
+    """
+    The base class for all items. This is a wrapper for the internal Item
+    interface. You should not need this unless you need the Urgency enum.
+    """
+
+    class Urgency(Enum):
+
+        Alert = 0
+        Notification = 1
+        Normal = 2
+
+
+class Item(object):
+    """
+    Represents a result item. Objects of this class are intended to be returned
+    by the handleQuery function.
+    """
+
+    id: str
+    """
+    The identifier string of the item. It is used for ranking algorithms and
+    should not be empty.
+    """
+
+    icon: str
+    """
+    The path of the icon displayed in the item.
+    """
+
+    text: str
+    """
+    The primary text of the item.
+    """
+
+    actions: List["ActionBase"]
+    """
+    The actions of the item. See action classes.
+    """
+
+    subtext: str
+    """
+    The secondary text of the item. This text should have informative character.
+    """
+
+    completion: str
+    """
+    The completion string of the item. This string will be used to replace the
+    input line when the user hits the Tab key on an item. Note that the
+    semantics may vary depending on the context.
+    """
+
+    urgency: ItemBase.Urgency
+    """
+    The urgency of the item. Note that the Urgency enum is defined in the
+    ItemBase class. See the Urgency enum.
+    """
+
+    def __init__(
+            self,
+            id: str = "",
+            icon: str = ":python_module",
+            text: str = "",
+            subtext: str = "",
+            actions: List["ActionBase"] = [],
+            completion: Optional[str] = None,
+            urgency: ItemBase.Urgency = ItemBase.Urgency.Normal,
+    ):
+        """
+        id: The identifier string of the item. It is used for ranking algorithms
+            and should not be empty.
+        icon: The path of the icon displayed in the item.
+        text: The primary text of the item.
+        actions: The actions of the item. See action classes.
+        subtext: The secondary text of the item. This text should have
+                 informative character.
+        completion: The completion string of the item. This string will be used
+                    to replace the input line when the user hits the Tab key on
+                    an item.  Note that the semantics may vary depending on the
+                    context.
+        urgency: The urgency of the item. Note that the Urgency enum is defined
+                 in the ItemBase class. See the Urgency enum.
+        """
+
+    def addAction(self, action: "ActionBase") -> None:
+        """
+        Add an action to the item.
+        """
+
+
+class ActionBase(object):
+    """
+    The base class for all actions is ActionBase. This is a wrapper for the
+    internal Action interface. You should not need it (If you think you do I‘d
+    be interested why. Please contact me in this case.). There is also a set of
+    standard actions subclassing ActionBase which should cover virtually every
+    usecases.
+    """
+
+
+class ClipAction(ActionBase):
+
+    def __init__(self, text: str = "", clipboardText=""):
+        """
+        This class copies the given text to the clipboard on activation.
+        """
+
+
+class UrlAction(ActionBase):
+
+    def __init__(self, text: str = "", url: str = ""):
+        """
+        This class opens the given URL with the systems default URL handler for
+        the scheme of the URL on activation.
+        """
+
+
+class ProcAction(ActionBase):
+
+    def __init__(
+            self,
+            text: str = "",
+            commandline: List[str] = [],
+            cwd: Optional[str] = None,
+    ):
+        """
+        This class executes the given commandline as a detached process on
+        activation. Optionally the working directory of the process can be set.
+        """
+
+
+class TermAction(ActionBase):
+
+    class CloseBehavior(Enum):
+
+        CloseOnSuccess = 0
+        CloseOnExit = 1
+        DoNotClose = 2
+
+    def __init__(
+            self,
+            text: str = "",
+            commandline: List[str] = [],
+            cwd: Optional[str] = None,
+            script: str = "",
+            behavior: CloseBehavior = CloseBehavior.CloseOnSuccess,
+    ):
+        """
+        This class executes the given commandline in the terminal set in the
+        preferences. Optionally the working directory of the process can be set.
+        This is the first form, which uses the commandline and cwd arguments.
+
+        In the second form, script and behavior are used to execute a script of
+        commands in the shell.
+        """
+
+
+class FuncAction(ActionBase):
+
+    def __init__(
+            self,
+            text: str = "",
+            callable: Callable[[], None] = lambda: None,
+    ):
+        """
+        This class is a general purpose action. On activation the callable is
+        executed.
+        """

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+
+setup(
+    name="albert-python-api",
+    version="0.4",
+    description="module interface for Albert launcher",
+    url="https://albertlauncher.github.io/",
+    license="Free To Use With Restrictions",
+    classifiers=[
+        "License :: Free To Use But Restricted",
+        "Development Status :: 3 - Alpha",
+    ],
+    packages=["albert"],
+    package_data={
+        "albert": ["__init__.pyi"],
+    },
+)


### PR DESCRIPTION
Although the albert python module can't be pushed to PyPI, the interface
definition can be declared in a .pyi file (usable as type stubs). Create
these stubs and package them into the albert-python-api module, along
with a dummy "albert" module which raises an ImportError.

This allows well-behaved static analyzers, type checkers, and language
servers to see the albert module's type definitions. They can provide
static checks as well as code completion while using a properly
configured editor (e.g. any editor supporting LSP, plus pyls).

The `albert/__init__.py` dummy module is required to be included in this
package. Unfortunately, although PEP 561 allows for standalone "-stubs"
modules to be published separate from the module definition, typical
tools (like Jedi completion) will attempt to find a module, and then
search for the module-stubs package if the module is found. Without an
"albert" module defined somewhere on sys.path, the "albert-stubs"
definitions would not be loaded. Thus, the easiest solution is to
include a dummy "albert" package with the stubs alongside it. This does
not impact plugins -- when they execute "import albert", the
already-loaded "albert" builtin module will take precedence over the
dummy `albert/__init__.py` here.

---

To test/try this out:
1. Build the package (`python setup.py sdist`) and install it (`pip install --user dist/albert-python-api-0.4.tar.gz`).
2. If you already have an editor with a Python language server set up, skip this. Otherwise, install visual studio code. Install the "ms-python" extension.
3. Create a new python file, and add some text for a bare-bones albert python module. As you type, you should be able to get completion for the attributes of each class, for the arguments of each constructor, and this should include docstrings copied straight out of README.md. See the attached screenshot.

![image](https://user-images.githubusercontent.com/5682515/118738941-0e551d00-b7fd-11eb-9887-96a82bb2ce8b.png)

I thought that it would be best for you, the Albert maintainer, to own this package in PyPI, so you can publish updates as the extension API changes. However, I'm also happy to maintain the package in a third party repo if you'd rather not include this or have the extra work. Let me know if you're interested in this change or how you'd like to move forward.

(also, thanks for an excellent launcher, it's very useful!)
