### PR TITLE
Added support for theme reloading on the widgetsboxmodel plugin

### DIFF
--- a/widgetsboxmodel/src/plugin.cpp
+++ b/widgetsboxmodel/src/plugin.cpp
@@ -874,3 +874,10 @@ void Plugin::handleQuery(Query &query) const
             );
 }
 
+void Plugin::reloadTheme ()
+{
+    theme_ = settings ()->value (CFG_THEME, DEF_THEME).toString ();
+
+    if (!setTheme (theme_))
+        WARN << "Stylefile not found on reload:" << theme_.toStdString().c_str();
+}

--- a/widgetsboxmodel/src/plugin.h
+++ b/widgetsboxmodel/src/plugin.h
@@ -23,6 +23,7 @@ public:
     const std::map<QString, QString> &themes() const;
     const QString &theme() const;
     bool setTheme(const QString& theme);
+    void reloadTheme () override;
 
     uint maxResults() const;
     void setMaxResults(uint max);


### PR DESCRIPTION
Added an option to reload the current theme's qss file.

Run
```albert reloadtheme```
to re-parse the qss file.

Useful for pywal users that auto-generate so we can generate the qss file ourselves. Needs of the PR I've just opened on the main project too.