### PR TITLE
Restrict clipboard history file permisions

### DIFF
--- a/clipboard/src/plugin.cpp
+++ b/clipboard/src/plugin.cpp
@@ -76,11 +76,10 @@ Plugin::~Plugin()
 
         QFile file(dataDir().filePath(HISTORY_FILE_NAME));
 
-        if (!file.setPermissions(QFile::ReadOwner | QFile::WriteOwner))
-            WARN << "Failed setting permissions on clipboard history.";
-
         if (file.open(QIODevice::WriteOnly))
         {
+            if (!file.setPermissions(QFile::ReadOwner | QFile::WriteOwner))
+                WARN << "Failed setting permissions on clipboard history.";
             DEBG << "Writing clipboard history to" << file.fileName();
             file.write(QJsonDocument(array).toJson());
             file.close();

--- a/clipboard/src/plugin.cpp
+++ b/clipboard/src/plugin.cpp
@@ -75,9 +75,13 @@ Plugin::~Plugin()
         }
 
         QFile file(dataDir().filePath(HISTORY_FILE_NAME));
+
+        if (!file.setPermissions(QFile::ReadOwner | QFile::WriteOwner))
+            WARN << "Failed setting permissions on clipboard history.";
+
         if (file.open(QIODevice::WriteOnly))
         {
-            DEBG << "Wrinting clipboard history to" << file.fileName();
+            DEBG << "Writing clipboard history to" << file.fileName();
             file.write(QJsonDocument(array).toJson());
             file.close();
         }


### PR DESCRIPTION
The default permissions on file creation leaves it open to be read by anyone, which is probably not wanted as this likely contains sensitive info.