### PR TITLE
Fix Overlapping Hint Text in InputLine During Unicode Input

### DIFF
--- a/widgetsboxmodel/src/inputline.cpp
+++ b/widgetsboxmodel/src/inputline.cpp
@@ -69,7 +69,9 @@ void InputLine::paintEvent(QPaintEvent *event)
 
         auto fm = fontMetrics();
         auto r = content_rect;
-        r.adjust(fm.horizontalAdvance(text()), 0, 0, 0);
+        int cursor_pos = cursorRect().right();
+        int offset = 5;
+        r.setLeft(cursor_pos + offset);        
         auto t = fm.elidedText(hint, Qt::ElideRight, r.width());
 
         p.drawText(r, Qt::TextSingleLine, t);


### PR DESCRIPTION
This pull request addresses the issue of overlapping hint text in the InputLine class when typing using Unicode input methods. Due to the nature of Unicode input, where characters are composed of multiple keystrokes (such as Korean and other languages), the hint text was overlapping with the input text during composition.

### Changes Made
#### Cursor Position Adjustment:

The paintEvent method has been modified to use the cursor's pixel position (cursorRect().right()) to determine the starting position for drawing the hint text. This ensures that the hint text does not overlap with the input text, even during the composition of Unicode characters.

#### Offset Addition:

An additional offset of 5 pixels has been added to the starting position of the hint text to further prevent any overlap and improve readability.

### Screenshot of current and PR
#### current
![albert_input_bug](https://github.com/albertlauncher/plugins/assets/405502/a2dc43ed-8213-4ad8-b8ff-be8f4faca1e4)


#### after applied PR
![after_fix_bug](https://github.com/albertlauncher/plugins/assets/405502/7a41e47b-97d5-4d9a-9672-edf1076b6955)
