### PR TITLE
fix org.gnome.ptyxis

### DIFF
--- a/applications/src/xdg/plugin.cpp
+++ b/applications/src/xdg/plugin.cpp
@@ -35,7 +35,7 @@ static const map<QString, QStringList> exec_args  // Desktop id > ExecArg
     {"org.gnome.terminal", {"--"}},
     {"org.kde.konsole", {"-e"}},  // Flatpak
     {"org.wezfurlong.wezterm", {"-e"}},  // Flatpak
-    {"ptyxis", {"--"}},
+    {"org.gnome.ptyxis", {"--"}},
     {"qterminal", {"-e"}},
     {"roxterm", {"-x"}},
     {"st", {"-e"}},


### PR DESCRIPTION
Terminal ptyxis's desktop entry filename should be org.gnome.Ptyxis.desktop
ref: https://gitlab.gnome.org/chergert/ptyxis/-/blob/main/data/org.gnome.Ptyxis.desktop.in.in