### PR TITLE
[applications] Fix XDG Desktop Entries shadowing behavior

### DIFF
--- a/applications/src/xdg/application.h
+++ b/applications/src/xdg/application.h
@@ -19,6 +19,15 @@ public:
         bool use_non_localized_name;
     };
 
+    enum class ExcludeReason
+    {
+        None,
+        NoDisplay,
+        NotShowIn,
+        OnlyShowIn,
+        EmptyExec,
+    };
+
     Application(const QString &id, const QString &path, ParseOptions po);
     Application(const Application &) = default;
 
@@ -28,6 +37,7 @@ public:
     std::vector<albert::Action> actions() const override final;
 
     const QStringList &exec() const;
+    const ExcludeReason &excludeReason() const;
 
 protected:
 
@@ -51,5 +61,6 @@ private:
     QString working_dir_;
     std::vector<DesktopAction> desktop_actions_;
     bool term_ = false;
+    ExcludeReason exclude_reason_ = ExcludeReason::None;
 
 };

--- a/applications/src/xdg/desktopentryparser.cpp
+++ b/applications/src/xdg/desktopentryparser.cpp
@@ -38,18 +38,17 @@ QString DesktopEntryParser::getRawValue(const QString &section, const QString &k
     class SectionDoesNotExist : public std::out_of_range { using out_of_range::out_of_range; };
     class KeyDoesNotExist : public std::out_of_range { using out_of_range::out_of_range; };
 
-    try {
-        auto &s = data.at(section);
-        try {
-            return s.at(key);
-        } catch (const out_of_range&) {
-            throw KeyDoesNotExist(QString("Section '%1' does not contain a key '%2'.")
-                                  .arg(section, key).toStdString());
-        }
-    } catch (const out_of_range&) {
+    auto s = data.find(section);
+    if (s == data.end())
         throw SectionDoesNotExist(QString("Desktop entry does not contain a section '%1'.")
                                   .arg(section).toStdString());
-    }
+
+    auto v = s->second.find(key);
+    if (v == s->second.end())
+        throw KeyDoesNotExist(QString("Section '%1' does not contain a key '%2'.")
+                              .arg(section, key).toStdString());
+
+    return v->second;
 }
 
 QString DesktopEntryParser::getEscapedValue(const QString &section, const QString &key) const


### PR DESCRIPTION
On my system, google-chrome is installed from the official debian package.
This creates a Desktop Entry in `/usr/share/applications/google-chrome.desktop`.
But I don't want to see google-chrome appear in my launchers, so I created a file `~/.local/share/applications/google-chrome.desktop` with `NoDisplay=true`.
This configuration works perfectly with other launchers (and this is the expected behavior, according to the spec.), but not with Albert.

The problem is that Albert treats excluded XDG Desktop Entry (with NoDisplay, NotShowIn, etc.) the same way as invalid entries.
And in this case, the entry is simply skipped and does not override/shadow later entries with the same ID.

So this PR fixes this behavior and makes Albert conform to the XDG Desktop Entry Specification.
When iterating desktop entry files, the old logic was:
- If a matching ID exists in the apps list -> skip
- Parse the file
- If invalid or excluded -> skip
- Add to the apps list

The new logic is:
- If a matching ID exists in the known apps list -> skip
- Parse the file
- If invalid -> skip
- Add to the known apps list
- If excluded -> skip
- Add to the apps list