### PR TITLE
Added alternate alacritty desktop ID to plugin.cpp

### DIFF
--- a/applications/src/xdg/plugin.cpp
+++ b/applications/src/xdg/plugin.cpp
@@ -14,6 +14,7 @@ using namespace albert;
 static const map<QString, QStringList> exec_args  // Desktop id > ExecArg
 {
     {"alacritty", {"-e"}},
+    {"com.alacritty.Alacritty", {"-e"}},
     {"app.devsuite.ptyxis", {"--"}},  // Flatpak
     {"blackbox", {"--"}},
     {"com.gexperts.tilix", {"-e"}},


### PR DESCRIPTION
Added additional line mentioning `com.alacritty.Alacritty` in addition to simple `alacritty`.